### PR TITLE
Return a filehandle instead of PDF content [#3]

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+Robert Rothenberg <perl@rhizomnic.com>  <robrwo@gmail.com>
+Robert Rothenberg <perl@rhizomnic.com>  <robrwo+github@gmail.com>
+Robert Rothenberg <perl@rhizomnic.com> Robert Rothenberg <rrwo@cpan.org>
+Robert Rothenberg <perl@rhizomnic.com> Robert Rothenberg <rrwo@cpansec.org>

--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl extension Catalyst::View::Wkhtmltopdf.
 
+{{$NEXT}}
+  [Enhancements]
+    - Return a filehandle instead of the PDF contents
+
 0.5.2
     - Fixed error in documentation (default stash key was wrong)
 

--- a/lib/Catalyst/View/Wkhtmltopdf.pm
+++ b/lib/Catalyst/View/Wkhtmltopdf.pm
@@ -139,6 +139,8 @@ sub render {
     my $output = `$hcmd`;
     die "$! [likely can't find wkhtmltopdf command!]" if $output;
 
+    die "Output file $pdffn not found" unless -e $pdffn;
+
     # Read the output and return it
     return IO::File::WithPath->new($pdffn);
 }

--- a/lib/Catalyst/View/Wkhtmltopdf.pm
+++ b/lib/Catalyst/View/Wkhtmltopdf.pm
@@ -8,8 +8,8 @@ our $VERSION = qv('0.5.2');
 
 use File::Temp;
 use URI::Escape;
-use Path::Class;
 use File::Spec;
+use IO::File::WithPath;
 
 has 'stash_key' => (
     is      => 'rw',
@@ -140,11 +140,7 @@ sub render {
     die "$! [likely can't find wkhtmltopdf command!]" if $output;
 
     # Read the output and return it
-    my $pdffc      = Path::Class::File->new($pdffn);
-    my $pdfcontent = $pdffc->slurp();
-    $pdffc->remove();
-    
-    return $pdfcontent;
+    return IO::File::WithPath->new($pdffn);
 }
 
 __PACKAGE__->meta->make_immutable();

--- a/lib/Catalyst/View/Wkhtmltopdf.pm
+++ b/lib/Catalyst/View/Wkhtmltopdf.pm
@@ -139,8 +139,6 @@ sub render {
     my $output = `$hcmd`;
     die "$! [likely can't find wkhtmltopdf command!]" if $output;
 
-    die "Output file $pdffn not found" unless -e $pdffn;
-
     # Read the output and return it
     return IO::File::WithPath->new($pdffn);
 }


### PR DESCRIPTION
This returns a filehandle instead of the actual content of the PDF.
It uses IO::File::WithPath so that the Plack XSendfile middleware
can work with HTTP servers that support X-Sendfile extensions to
have the PDF served directly by the web server.